### PR TITLE
Fix Next.js Link component issues by removing nested anchor tags

### DIFF
--- a/components/article-preview.js
+++ b/components/article-preview.js
@@ -13,8 +13,11 @@ export default function ArticlePreview({
 
   return (
     <div className="px-6 flex flex-col items-start">
-      <Link as={`/articles/${slug}`} href="/articles/[slug]">
-        <a className="sm:text-3xl text-2xl title-font font-medium text-gray-900 mt-4 mb-4">{title}</a>
+      <Link
+        as={`/articles/${slug}`}
+        href="/articles/[slug]"
+        className="sm:text-3xl text-2xl title-font font-medium text-gray-900 mt-4 mb-4">
+        {title}
       </Link>
       <div className="inline-flex">
         {date && (
@@ -26,15 +29,18 @@ export default function ArticlePreview({
       </div>
       {excerpt && <p className="leading-relaxed mt-4 mb-4">{excerpt}</p>}
       <div className="flex items-center flex-wrap pb-4 mb-4 border-b-2 border-gray-100 mt-auto w-full">
-        <Link as={`/articles/${slug}`} href="/articles/[slug]">
-          <a className="text-red-500 font-bold hover:underline hover:text-red-600 inline-flex items-center">Learn More
-            <svg className="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="4" fill="none" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M5 12h14"></path>
-              <path d="M12 5l7 7-7 7"></path>
-            </svg>
-          </a>
+        <Link
+          as={`/articles/${slug}`}
+          href="/articles/[slug]"
+          className="text-red-500 font-bold hover:underline hover:text-red-600 inline-flex items-center">
+          Learn More
+                      <svg className="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="4" fill="none" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 12h14"></path>
+            <path d="M12 5l7 7-7 7"></path>
+          </svg>
+
         </Link>
       </div>
     </div>
-  )
+  );
 }

--- a/components/header.js
+++ b/components/header.js
@@ -2,22 +2,24 @@ import Link from 'next/link'
 
 export default function Header({ subtitle }) {
   return (
-  <section className="flex-col flex items-left mt-20">
-    <div className="flex-row flex items-left text-left">
-      <Link href="/">
-        <a className="flex title-font font-medium items-center md:justify-start justify-center mr-4">
+    <section className="flex-col flex items-left mt-20">
+      <div className="flex-row flex items-left text-left">
+        <Link
+          href="/"
+          className="flex title-font font-medium items-center md:justify-start justify-center mr-4">
+
           <img src="/logo.png" className="w-12 h-12 mb-2" />
-        </a>
-      </Link>
-      <a href="/articles" className="pt-1 text-3xl text-red-500 hover:text-red-600 font-black hover:underline mr-4">Articles</a>
-      <a href="https://github.com/utensils" target="_blank" className="pt-1 text-3xl text-red-500 hover:text-red-600 font-black hover:underline">GitHub</a>
-    </div>
-    <div className="flex-col flex items-left mt-10">
-      <h1 className="text-8xl font-black tracking-tighter leading-tight md:pr-8">
-      Utensils
-      </h1>
-      <span className="lowercase text-4xl text-gray-400">{subtitle}</span>
-    </div>
-  </section>
-  )
+
+        </Link>
+        <a href="/articles" className="pt-1 text-3xl text-red-500 hover:text-red-600 font-black hover:underline mr-4">Articles</a>
+        <a href="https://github.com/utensils" target="_blank" className="pt-1 text-3xl text-red-500 hover:text-red-600 font-black hover:underline">GitHub</a>
+      </div>
+      <div className="flex-col flex items-left mt-10">
+        <h1 className="text-8xl font-black tracking-tighter leading-tight md:pr-8">
+        Utensils
+        </h1>
+        <span className="lowercase text-4xl text-gray-400">{subtitle}</span>
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
- Updated Link components in article-preview.js and header.js to follow Next.js 13+ standards
- Removed nested <a> tags inside <Link> components
- Moved className and other attributes from <a> tags to parent <Link> components
- Applied changes using the Next.js codemod tool

This fixes the "Invalid <Link> with <a> child" error as described in: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor